### PR TITLE
Add pop batch size support for ZMQ Consumer

### DIFF
--- a/common/zmqconsumerstatetable.h
+++ b/common/zmqconsumerstatetable.h
@@ -83,6 +83,8 @@ private:
     ZmqServer& m_zmqServer;
 
     std::unique_ptr<AsyncDBUpdater> m_asyncDBUpdater;
+
+    size_t m_popBatchSize;
 };
 
 }


### PR DESCRIPTION
What i did

Add pop batch size support to ZmqConsumerState Table to optimize memory when applying dash configuration at scale to 202506